### PR TITLE
Properly assign BPM offset

### DIFF
--- a/tools/Guidelines/EnterBPMLayer.cpp
+++ b/tools/Guidelines/EnterBPMLayer.cpp
@@ -72,7 +72,7 @@ void EnterBPMLayer::onCreate(CCObject*) {
     
     if (m_pOffsetInput->getString() && strlen(m_pOffsetInput->getString()))
         try {
-            std::stof(m_pOffsetInput->getString());
+            offset = std::stof(m_pOffsetInput->getString());
         } catch (...) {}
 
     std::vector<char> pattern {};


### PR DESCRIPTION
Currently, the BPM tool does not use the converted float value from the offset string. This should fix that problem.