### PR TITLE
Fix reference cycle caused by EditableBMLabelProxy

### DIFF
--- a/src/utils/EditableBMLabelProxy.hpp
+++ b/src/utils/EditableBMLabelProxy.hpp
@@ -10,7 +10,7 @@ using namespace geode::prelude;
 class EditableBMLabelProxy : public CCLabelBMFont, TextInputDelegate {
 protected:
     Ref<InputNode> m_input = nullptr;
-    Ref<CCNode> m_inputParent = nullptr;
+    CCNode* m_inputParent = nullptr;
     std::function<void(std::string const&)> m_onSetValue = nullptr;
     std::function<void(std::string const&)> m_onUpdate = nullptr;
     bool m_ignoreLabelUpdate = false;


### PR DESCRIPTION
this would cause the parent to not be free'd properly, creating a phantom EditorUI which is the source of many crashes.

In my testing, this has eliminated any consistent crashes I was getting