### PR TITLE
Add Hide Trigger Backgrounds

### DIFF
--- a/mod.json
+++ b/mod.json
@@ -167,6 +167,12 @@
 			"name": "Larger Color Menu",
 			"description": "If you're using the <cr>New Color Menu</c>, this makes the color channel buttons a bit larger"
 		},
+		"hide-trigger-ui": {
+			"type": "bool",
+			"default": false,
+			"name": "Hide Trigger Backgrounds",
+			"description": "Hides the <cc>backgrounds</c> on all triggers when using sliders, like with <cl>shader</c> triggers"
+		},
 		"grid-size-controls": {
 			"type": "bool",
 			"default": true,

--- a/src/features/ForceHideTriggerUI.cpp
+++ b/src/features/ForceHideTriggerUI.cpp
@@ -1,0 +1,29 @@
+#include <Geode/Geode.hpp>
+#include <Geode/modify/SetupTriggerPopup.hpp>
+
+using namespace geode::prelude;
+
+class $modify (SetupTriggerPopup)
+{
+    virtual void sliderBegan(Slider* slider)
+    {
+        SetupTriggerPopup::sliderBegan(slider);
+
+        if (!Mod::get()->getSettingValue<bool>("hide-trigger-ui"))
+            return;
+
+        getChildOfType<CCScale9Sprite>(m_mainLayer, 0)->runAction(CCFadeTo::create(0.15f, 0));
+        this->runAction(CCFadeTo::create(0.15f, 0));
+    }
+
+    virtual void sliderEnded(Slider* slider)
+    {
+        SetupTriggerPopup::sliderEnded(slider);
+
+        if (!Mod::get()->getSettingValue<bool>("hide-trigger-ui"))
+            return;
+
+        getChildOfType<CCScale9Sprite>(m_mainLayer, 0)->runAction(CCFadeTo::create(0.15f, 255));
+        this->runAction(CCFadeTo::create(0.15f, 150));
+    }
+};


### PR DESCRIPTION
Hides the background of trigger popups when using sliders, like how with the shader triggers

https://github.com/user-attachments/assets/c1947a50-6736-4f64-be7c-32fae9d5b562

