### PR TITLE
fix text getting unhighlighted on font change

### DIFF
--- a/src/features/BetterFontSelect.cpp
+++ b/src/features/BetterFontSelect.cpp
@@ -19,6 +19,9 @@ class $modify(BetterSelectFontLayer, SelectFontLayer) {
     void onSelect(CCObject* sender) {
         int s = static_cast<CCNode*>(sender)->getTag();
         GameManager::get()->m_levelEditorLayer->updateLevelFont(s);
+        if (auto EUI = EditorUI::get()) {
+            EUI->resetSelectedObjectsColor();
+        }
 
         for (size_t i = 0; i < SelFont::buttons.size(); i++) {
             if (i != static_cast<size_t>(s)) {


### PR DESCRIPTION
This PR is a reimplementation of https://github.com/Cvolton/miscbugfixes-geode/pull/33 for BetterEdit's BetterFontSelect.

When you select a text object and then change the font in the level, it resets the highlight color. This is a vanilla issue (see the Misc Bugfixes PR and the issue it addresses for more detail), however the vanilla bugfix included in Misc Bugfixes mod doesn't work with BetterEdit, since it reimplements the respective function. This PR ports Hbg1010's fix to BetterEdit.