### PR TITLE
Fix typo in "Build Helper" keybind setting description

### DIFF
--- a/mod.json
+++ b/mod.json
@@ -338,7 +338,7 @@
         "keybind-build-helper": {
 			"type": "keybind",
         	"name": "Build Helper",
-        	"description": "Executes the <cy>Build Helper</c> feature, aka remaps Groud and Color IDs of the selected objects to unused ones",
+        	"description": "Executes the <cy>Build Helper</c> feature, aka remaps Group and Color IDs of the selected objects to unused ones",
         	"category": "editor",
 			"default": [],
 			"migrate-from": "hjfod.betteredit/build-helper"


### PR DESCRIPTION
This just fixes a typo in the description of the `keybind-build-helper` setting (Grou*d* -> Grou*p*). 